### PR TITLE
Changed text width scale factor for metapost

### DIFF
--- a/internal/metapost.js
+++ b/internal/metapost.js
@@ -559,7 +559,7 @@ function isLeaf(block) {
     //L(strippedContent + ': ' + autowrap);
     if (autowrap) {
       var width = this.width().getOrDie() / 210;  // Hack: need to find right ratio
-      width /= this.fontSize().get() / 28;
+      width /= this.fontSize().get() / 32;
       //L(content + ': ' + this.width().get());
       content = '\\begin{minipage}{'+width+'in}\n' + content + '\n\\end{minipage}';
     }


### PR DESCRIPTION
I noticed that in the rendered PDF slides, the auto-wrapped texts usually do not fill the entire slide width. Here are the examples before and after I changed the font scaling factor.

![bad](https://cloud.githubusercontent.com/assets/5135317/3465884/7c977084-0273-11e4-87ba-e0e94a6e4798.png)
![good](https://cloud.githubusercontent.com/assets/5135317/3465885/7fd81b2c-0273-11e4-8e58-fa89ba51dd21.png)

 I do not know if this is font-dependent, but I noticed the same effect on [Jonathan's slides](http://cs.stanford.edu/~pliang/papers/freebase-emnlp2013-talk.pdf) (PDF pages 5, 14, 24) as well.
